### PR TITLE
新增了冷却方式

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ MiraiConsolePlugin 自定义戳一戳回复消息
 - `#group.mute:30` 禁言30s, 可以自定义禁言时间, 单位秒
 - `#ignore` 忽略
 
+Tips：可以在#nudge之后直接添加消息以在回戳时同时回复消息
 ## 配置文件
 
 文件位置：`config/me.jie65535.mirai-console-jnr-plugin/jnr.yml`
@@ -37,6 +38,21 @@ priority: HIGH
 isIntercept: true
 # 群回复间隔（秒），0表示无限制
 groupInterval: 0
+# 群共享冷却时间上界（分钟），0表示无限制
+# 请不要和群回复间隔一起打开，避免出现问题
+groupCoolDownTimeUpperBound: 0
+# 群共享冷却时间下界（分钟），0表示无限制
+# 以下界<=x<=上界为范围产生随机数随机休息时间
+groupCoolDownTimeLowerBound: 0
+# 冷却触发发送语句
+# %s为占位符，可不加，用来在消息中显示冷却时长
+replyMessageForRest: 呜呜，被戳傻了。休息%s分钟
+# 群共享冷却默认触发最低次数
+groupCoolDownTriggerCountMin: 6
+# 群共享冷却默认触发最高次数，到此次数必定触发
+groupCoolDownTriggerCountMax: 12
+# 达到最低次数后的触发概率,1~100，按百分比触发
+groupCoolDownTriggerProbability: 50
 # 用户私聊回复间隔（秒），0表示无限制
 userInterval: 0
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ groupCoolDownTriggerCountMin: 6
 groupCoolDownTriggerCountMax: 12
 # 达到最低次数后的触发概率,1~100，按百分比触发
 groupCoolDownTriggerProbability: 50
+# 间隔多长时间重置计数（分钟），0表示不重置
+groupCoolDownInterval: 10
 # 用户私聊回复间隔（秒），0表示无限制
 userInterval: 0
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ groupInterval: 0
 # 群共享冷却时间上界（分钟），0表示无限制
 # 请不要和群回复间隔一起打开，避免出现问题
 groupCoolDownTimeUpperBound: 0
-# 群共享冷却时间下界（分钟），0表示无限制
+# 群共享冷却时间下界（分钟）
 # 以下界<=x<=上界为范围产生随机数随机休息时间
 groupCoolDownTimeLowerBound: 0
 # 冷却触发发送语句

--- a/src/main/kotlin/top/jie65535/jnr/JNRPluginConfig.kt
+++ b/src/main/kotlin/top/jie65535/jnr/JNRPluginConfig.kt
@@ -44,19 +44,21 @@ object JNRPluginConfig : AutoSavePluginConfig("jnr") {
     /**
      * 群共享冷却时间
      * 本设定优先级低于群间隔时间
-     * 如需使用请将群间隔时间设置为0*/
-    @ValueDescription("群共享冷却时间上界，0表示无限制")
+     * 如需使用请将群间隔时间设置为0
+     * 请不要一起打开
+     * */
+    @ValueDescription("群共享冷却时间上界（分钟），0表示无限制")
     var groupCoolDownTimeUpperBound: Long by value(0L)
-    @ValueDescription("群共享冷却时间下界，0表示无限制")
+    @ValueDescription("群共享冷却时间下界（分钟），0表示无限制")
     var groupCoolDownTimeLowerBound: Long by value(0L)
-    @ValueDescription("冷却触发发送语句")
+    @ValueDescription("冷却触发发送语句,%s为占位符，可不加，用来在消息中显示冷却时长")
     var replyMessageForRest: String by value("呜呜，被戳傻了。休息%s分钟")
     @ValueDescription("群共享冷却默认触发最低次数")
-    var groupCoolDownTriggerCountMin: Long by value(0L)
+    var groupCoolDownTriggerCountMin: Long by value(6L)
     @ValueDescription("群共享冷却默认触发最高次数，到此次数必定触发")
-    var groupCoolDownTriggerCountMax: Long by value(0L)
+    var groupCoolDownTriggerCountMax: Long by value(12L)
     @ValueDescription("达到最低次数后的触发概率,1~100，按百分比触发")
-    var groupCoolDownTriggerProbability: Int by value(0)
+    var groupCoolDownTriggerProbability: Int by value(50)
     /**
      * 用户间隔（单位秒）
      * 0 表示无限制

--- a/src/main/kotlin/top/jie65535/jnr/JNRPluginConfig.kt
+++ b/src/main/kotlin/top/jie65535/jnr/JNRPluginConfig.kt
@@ -42,6 +42,21 @@ object JNRPluginConfig : AutoSavePluginConfig("jnr") {
     var groupInterval: Long by value(0L)
 
     /**
+     * 群共享冷却时间
+     * 本设定优先级高于群间隔时间*/
+    @ValueDescription("群共享冷却时间上界，0表示无限制")
+    var groupCoolDownTimeUpperBound: Long by value(0L)
+    @ValueDescription("群共享冷却时间下界，0表示无限制")
+    var groupCoolDownTimeLowerBound: Long by value(0L)
+    @ValueDescription("冷却触发发送语句")
+    var replyMessageForRest: String by value("呜呜，被戳傻了。休息%s分钟")
+    @ValueDescription("群共享冷却默认触发最低次数")
+    var groupCoolDownTriggerCountMin: Long by value(0L)
+    @ValueDescription("群共享冷却默认触发最高次数，到此次数必定触发")
+    var groupCoolDownTriggerCountMax: Long by value(0L)
+    @ValueDescription("达到最低次数后的触发概率,1~100，按百分比触发")
+    var groupCoolDownTriggerProbability: Int by value(0)
+    /**
      * 用户间隔（单位秒）
      * 0 表示无限制
      */

--- a/src/main/kotlin/top/jie65535/jnr/JNRPluginConfig.kt
+++ b/src/main/kotlin/top/jie65535/jnr/JNRPluginConfig.kt
@@ -43,7 +43,8 @@ object JNRPluginConfig : AutoSavePluginConfig("jnr") {
 
     /**
      * 群共享冷却时间
-     * 本设定优先级高于群间隔时间*/
+     * 本设定优先级低于群间隔时间
+     * 如需使用请将群间隔时间设置为0*/
     @ValueDescription("群共享冷却时间上界，0表示无限制")
     var groupCoolDownTimeUpperBound: Long by value(0L)
     @ValueDescription("群共享冷却时间下界，0表示无限制")

--- a/src/main/kotlin/top/jie65535/jnr/JNRPluginConfig.kt
+++ b/src/main/kotlin/top/jie65535/jnr/JNRPluginConfig.kt
@@ -59,6 +59,8 @@ object JNRPluginConfig : AutoSavePluginConfig("jnr") {
     var groupCoolDownTriggerCountMax: Long by value(12L)
     @ValueDescription("达到最低次数后的触发概率,1~100，按百分比触发")
     var groupCoolDownTriggerProbability: Int by value(50)
+    @ValueDescription("间隔多长时间重置计数（分钟），0表示不重置")
+    var groupCoolDownInterval: Long by value(10L)
     /**
      * 用户间隔（单位秒）
      * 0 表示无限制

--- a/src/main/kotlin/top/jie65535/jnr/JNRPluginConfig.kt
+++ b/src/main/kotlin/top/jie65535/jnr/JNRPluginConfig.kt
@@ -49,7 +49,7 @@ object JNRPluginConfig : AutoSavePluginConfig("jnr") {
      * */
     @ValueDescription("群共享冷却时间上界（分钟），0表示无限制")
     var groupCoolDownTimeUpperBound: Long by value(0L)
-    @ValueDescription("群共享冷却时间下界（分钟），0表示无限制")
+    @ValueDescription("群共享冷却时间下界（分钟）")
     var groupCoolDownTimeLowerBound: Long by value(0L)
     @ValueDescription("冷却触发发送语句,%s为占位符，可不加，用来在消息中显示冷却时长")
     var replyMessageForRest: String by value("呜呜，被戳傻了。休息%s分钟")

--- a/src/main/kotlin/top/jie65535/jnr/JNudgeReply.kt
+++ b/src/main/kotlin/top/jie65535/jnr/JNudgeReply.kt
@@ -70,7 +70,7 @@ object JNudgeReply : KotlinPlugin(
                             groupCoolDownTime[subject.id] = now
                         if (!isReply && (groupCoolDownTime[subject.id]?.plusMinutes(coolDownTime.toLong())!! > now)){
                             logger.info("cd中，跳过")
-                        }else if ((randomNumber >= (100-JNRPluginConfig.groupCoolDownTriggerProbability) && jnrCount >= JNRPluginConfig.groupCoolDownTriggerCountMin) || (jnrCount >= JNRPluginConfig.groupCoolDownTriggerCountMax)){
+                        }else if ((randomNumber <= JNRPluginConfig.groupCoolDownTriggerProbability && jnrCount >= JNRPluginConfig.groupCoolDownTriggerCountMin) || (jnrCount >= JNRPluginConfig.groupCoolDownTriggerCountMax)){
                             groupCoolDownTime[subject.id] = now
                             isReply = false
                             jnrCount = 1

--- a/src/main/kotlin/top/jie65535/jnr/JNudgeReply.kt
+++ b/src/main/kotlin/top/jie65535/jnr/JNudgeReply.kt
@@ -65,8 +65,6 @@ object JNudgeReply : KotlinPlugin(
                         }
                     } else if (JNRPluginConfig.groupCoolDownTimeUpperBound > 0) {
                         val randomNumber = (1..100).random()
-                        logger.info(randomNumber.toString())
-                        logger.info(JNRPluginConfig.groupCoolDownTriggerProbability.toString())
                         if (groupCoolDownTime[subject.id] == null)
                             groupCoolDownTime[subject.id] = now
                             groupJnrCount[subject.id] = 1


### PR DESCRIPTION
新增了冷却方式（仅群聊），将回戳也改为模糊识别，可以一并回复消息，实现了#10 的一部分功能
新增冷却方式效果如图，在冷却时间段内（图中是十分钟）不会回复戳一戳请求
![9F7E0D620EBC89636B93E68D1950C08A](https://user-images.githubusercontent.com/88184993/225081243-17cbf94f-ccb2-477a-af91-04b5cca57ca9.jpg)
