### PR TITLE
升级和修复

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     kotlin("jvm") version kotlinVersion
     kotlin("plugin.serialization") version kotlinVersion
 
-    id("net.mamoe.mirai-console") version "2.14.0"
+    id("net.mamoe.mirai-console") version "2.16.0"
 }
 
 group = "top.jie65535"


### PR DESCRIPTION
- 升级 mirai-console 依赖到 2.16.0

- 使用 Mirai kdoc 推荐的图片上传方式，修复图片宽高异常的问题
> 最推荐的存储方式是存储图片原文件, 每次发送图片时都使用文件上传. 在上传时服务器会根据其缓存情况回复已有的图片 ID 或要求客户端上传.